### PR TITLE
refactor: rename shadowed variable F to frac in LunarPhase

### DIFF
--- a/lunar.go
+++ b/lunar.go
@@ -123,8 +123,8 @@ func LunarPhase(t time.Time) LunarPhaseInfo {
 
 	K := 100 * (1 + cosx(PA)) / 2
 
-	F := (1 - cosx(d)) / 2
-	days := F * lunarMonthDays
+	frac := (1 - cosx(d)) / 2
+	days := frac * lunarMonthDays
 
 	return LunarPhaseInfo{
 		Illumination: K,


### PR DESCRIPTION
## Summary

- Rename local variable `F` to `frac` in `LunarPhase` to avoid shadowing the Meeus convention where `F` = argument of latitude
- Purely cosmetic — no behavior change

## Changes

- **`lunar.go:126-127`**: `F` → `frac` (phase fraction)

## Testing

- All existing tests pass unchanged
- Full quality gate clean: `go test -race`, `go vet`, `golangci-lint`, `gofmt`

## Related Issues

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)