### PR TITLE
fix: document JulianDate range limitation and add ValidJulianDateRange

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -14,8 +14,8 @@ const (
 // JulianDate returns the Julian date for a given time, i.e., the continuous
 // count of days and fractions of day since the beginning of the Julian period.
 //
-// Uses UnixNano internally, which limits the valid range to approximately
-// 1677-04-22 to 2262-04-11 (the int64 nanosecond bounds). Dates outside
+// Uses UnixNano internally, which limits the valid range to the int64
+// nanosecond bounds (approximately 1677-09-21 to 2262-04-11). Dates outside
 // this range silently produce incorrect results because UnixNano returns 0.
 // Use [ValidJulianDateRange] to check before calling.
 func JulianDate(t time.Time) float64 {
@@ -24,13 +24,14 @@ func JulianDate(t time.Time) float64 {
 }
 
 // ErrDateOutOfRange is returned when a date falls outside the valid range
-// for [JulianDate] (approximately 1677-04-22 to 2262-04-11).
-var ErrDateOutOfRange = errors.New("dusk: date outside valid range (~1677–2262) for JulianDate")
+// for [JulianDate] (the int64 nanosecond bounds, approximately
+// 1677-09-21 to 2262-04-11).
+var ErrDateOutOfRange = errors.New("dusk: date outside valid range (1677-09-21 to 2262-04-11) for JulianDate")
 
-// julianDateMin and julianDateMax are the approximate bounds of UnixNano.
+// julianDateMin and julianDateMax are the bounds of the int64 UnixNano range.
 var (
-	julianDateMin = time.Date(1678, 1, 1, 0, 0, 0, 0, time.UTC)
-	julianDateMax = time.Date(2262, 1, 1, 0, 0, 0, 0, time.UTC)
+	julianDateMin = time.Unix(0, math.MinInt64).UTC()
+	julianDateMax = time.Unix(0, math.MaxInt64).UTC()
 )
 
 // ValidJulianDateRange reports whether t falls within the valid range for

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -45,16 +45,23 @@ func TestJulianDate(t *testing.T) {
 }
 
 func TestValidJulianDateRange(t *testing.T) {
+	minValid := time.Unix(0, math.MinInt64).UTC()
+	maxValid := time.Unix(0, math.MaxInt64).UTC()
+
 	tests := []struct {
 		name    string
 		time    time.Time
 		wantErr bool
 	}{
 		{"valid 2024", time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC), false},
-		{"valid 1700", time.Date(1700, 1, 1, 0, 0, 0, 0, time.UTC), false},
-		{"valid 2200", time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"valid min boundary", minValid, false},
+		{"valid max boundary", maxValid, false},
 		{"too early 1600", time.Date(1600, 1, 1, 0, 0, 0, 0, time.UTC), true},
 		{"too late 2300", time.Date(2300, 1, 1, 0, 0, 0, 0, time.UTC), true},
+		{"just before min", minValid.Add(-time.Nanosecond), true},
+		{"just after min", minValid.Add(time.Nanosecond), false},
+		{"just before max", maxValid.Add(-time.Nanosecond), false},
+		{"just after max", maxValid.Add(time.Nanosecond), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Expand `JulianDate` godoc with explicit valid range warning (~1677–2262)
- Add `ErrDateOutOfRange` sentinel error
- Add `ValidJulianDateRange` helper for opt-in range checking
- No signature changes — backward compatible

## Changes

- **`epoch.go`**: Enhanced godoc, new `ErrDateOutOfRange`, `julianDateMin`/`julianDateMax` bounds, `ValidJulianDateRange` function
- **`epoch_test.go`**: Tests for valid and out-of-range dates

## Testing

- All tests pass with `-race`
- Full quality gate clean: `go vet`, `golangci-lint`, `gofmt`

## Related Issues

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)