### PR TITLE
docs: update documentation for v2.1.0 release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,17 +15,18 @@ go test -v -run TestName ./...  # Run single test
 
 Single package at the repo root. Zero dependencies. Module path: `github.com/philoserf/dusk/v2`.
 
-| File              | Domain                                                          |
-| ----------------- | --------------------------------------------------------------- |
-| `trig.go`         | Degree-based trig wrappers, `mod360`/`mod24` normalization      |
-| `epoch.go`        | Julian dates, sidereal time, nutation, obliquity                |
-| `coord.go`        | Coordinate types and ecliptic/equatorial/horizontal conversions |
-| `solar.go`        | Sun position, sunrise/sunset                                    |
-| `lunar.go`        | Moon position (Meeus tables), moonrise/moonset, phase           |
-| `lunar_tables.go` | Meeus Table 47.A/B coefficients                                 |
-| `transit.go`      | Object rise/set/transit for arbitrary equatorial coordinates    |
-| `twilight.go`     | Civil, nautical, astronomical twilight                          |
-| `doc.go`          | Package documentation                                           |
+| File              | Domain                                                                   |
+| ----------------- | ------------------------------------------------------------------------ |
+| `trig.go`         | Degree-based trig wrappers, `clamp`, `mod360`/`mod24` normalization      |
+| `epoch.go`        | Julian dates, sidereal time, nutation, obliquity, `ValidJulianDateRange` |
+| `coord.go`        | Coordinate types, validation, ecliptic/equatorial/horizontal conversions |
+| `solar.go`        | Sun position, sunrise/sunset, `computeSolarParams` shared helper         |
+| `lunar.go`        | Moon position (Meeus tables), moonrise/moonset, phase                    |
+| `lunar_tables.go` | Meeus Table 47.A/B coefficients                                          |
+| `transit.go`      | Object rise/set/transit (analytical maximum) for equatorial coordinates  |
+| `twilight.go`     | Civil, nautical, astronomical twilight (uses `computeSolarParams`)       |
+| `stringer.go`     | `fmt.Stringer` implementations for all exported result types             |
+| `doc.go`          | Package documentation                                                    |
 
 ## Key Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v2.1.0 — 2026-03-10
+
+### New features
+
+- `fmt.Stringer` interface on all 8 exported result types (`SunEvent`, `MoonEvent`, `LunarPhaseInfo`, `Transit`, `TwilightEvent`, `Equatorial`, `Ecliptic`, `Horizontal`)
+- `ValidJulianDateRange` helper and `ErrDateOutOfRange` sentinel for guarding `JulianDate` range (~1677–2262)
+
+### Bug fixes
+
+- `asinx`/`acosx` now clamp inputs to [-1, 1] via `clamp()`, preventing NaN from floating-point rounding
+- `validateEquatorial` normalizes RA via `mod360` instead of rejecting values at 360.0; rejects NaN/Inf inputs
+
+### Performance
+
+- `ObjectTransit` transit maximum: replaced O(n) minute-by-minute scan with O(1) analytical solution (hour angle = 0)
+
+### Refactoring
+
+- Extracted `computeSolarParams` helper eliminating 3× duplication of the 6-step solar parameter sequence; `twilight()` reduced from 44 to 29 lines
+- Renamed shadowed variable `F` → `frac` in `LunarPhase`
+
+### Testing
+
+- Fuzz tests for `SunriseSunset`, `LunarPhase`, `ObjectTransit`, `MoonriseMoonset`
+- Benchmarks for `MoonriseMoonset`, `LunarEclipticPosition`, `SunriseSunset`, `ObjectTransit` (0 allocations)
+- Polar twilight transition test (75°N, Nov 25→26)
+- Negative elevation clamping, summer solstice solar position, GMST/julianCentury helper tests
+- Southern hemisphere moonrise/moonset regression references
+- Consistent `t.Run` subtests for `TestMod360`/`TestMod24`; table-driven `TestEclipticToEquatorial`
+
+### Infrastructure
+
+- `.golangci.yml` with explicit linter list (gocritic, revive, misspell, etc.); `captLocal` disabled for Meeus conventions
+- 80% coverage threshold in CI (currently 99.7%); removed duplicate `go vet` step
+
+### Documentation
+
+- `Observer.Elev` doc comment: negative value clamping, scope (sunrise/sunset/twilight only)
+- `gstToUT` precision note about J1900-epoch model accuracy
+
 ## v2.0.0 — 2026-03-06
 
 Complete rewrite of the library. Zero external dependencies.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ fmt.Printf("Set:     %s\n", tr.Set.Format(time.Kitchen))
 ### Epoch
 
 - `JulianDate` — Julian date from `time.Time`
+- `ValidJulianDateRange` — check whether a date is within `JulianDate`'s valid range
 - `LocalSiderealTime` — LST for a given longitude
 
 ## Conventions
@@ -115,6 +116,7 @@ fmt.Printf("Set:     %s\n", tr.Set.Format(time.Kitchen))
 - `Observer.Lon` is **east-positive, west-negative** (e.g., New York is −74.006).
 - Functions that can fail return `error`. Two sentinel errors distinguish polar edge cases: `ErrCircumpolar` (object always above the horizon) and `ErrNeverRises` (object never rises).
 - A **zero-value `time.Time`** signals "event did not occur" (e.g., the Moon does not rise on a given day). Check with `.IsZero()`.
+- All result types implement **`fmt.Stringer`** for convenient display.
 - Twilight functions return tonight's **Dusk** and tomorrow morning's **Dawn**. To get this morning's dawn, call with yesterday's date.
 
 ## Accuracy

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,7 +1,7 @@
 # Dusk: Astronomical Calculations Library — Code Walkthrough
 
-*2026-03-09T03:42:45Z by Showboat 0.6.1*
-<!-- showboat-id: 5522f23e-041b-4abf-91ce-83ae538b0fc6 -->
+*2026-03-10T00:36:13Z by Showboat 0.6.1*
+<!-- showboat-id: 4b2dcd3a-9851-4216-88af-c8b5f37e074e -->
 
 ## Overview
 
@@ -14,7 +14,7 @@ Dusk is a zero-dependency Go library for astronomical calculations. It computes 
 - Sentinel errors `ErrCircumpolar` / `ErrNeverRises` for polar edge cases
 - Single package, domain-focused files, zero external dependencies
 
-The code has a clear dependency flow. We'll walk through it bottom-up: trig primitives → time/epoch foundations → coordinate conversions → solar calculations → lunar calculations → transit → twilight.
+The code has a clear dependency flow. We'll walk through it bottom-up: trig primitives → time/epoch foundations → coordinate conversions → solar calculations → lunar calculations → transit → twilight → string formatting.
 
 ### Project structure
 
@@ -23,15 +23,16 @@ find . -name "*.go" -not -name "*_test.go" | sort | while read f; do echo "$(wc 
 ```
 
 ```output
-144 lines  ./coord.go
+154 lines  ./coord.go
 17 lines  ./doc.go
-114 lines  ./epoch.go
+139 lines  ./epoch.go
 167 lines  ./lunar_tables.go
 257 lines  ./lunar.go
-140 lines  ./solar.go
-142 lines  ./transit.go
-35 lines  ./trig.go
-83 lines  ./twilight.go
+154 lines  ./solar.go
+71 lines  ./stringer.go
+141 lines  ./transit.go
+40 lines  ./trig.go
+66 lines  ./twilight.go
 ```
 
 ```bash
@@ -44,16 +45,16 @@ module github.com/philoserf/dusk/v2
 go 1.24
 ```
 
-Zero external dependencies — only `math`, `time`, and `errors` from the standard library. The entire library is ~1,100 lines of source code.
+Zero external dependencies — only `math`, `time`, `errors`, and `fmt` from the standard library. The entire library is ~1,200 lines of source code.
 
 ---
 
 ## Layer 1: Trig Primitives (`trig.go`)
 
-The foundation. Every astronomical formula in the library works in degrees, but Go's `math` package uses radians. These wrappers eliminate conversion clutter throughout the codebase.
+Every astronomical formula in this library works in degrees, but Go's `math` package works in radians. `trig.go` bridges the gap with thin wrappers, plus angle-normalization utilities used everywhere.
 
 ```bash
-sed -n "1,19p" trig.go
+sed -n "1,24p" trig.go
 ```
 
 ```output
@@ -66,11 +67,16 @@ const (
 	radToDeg = 180.0 / math.Pi
 )
 
+// clamp restricts x to [-1, 1] before passing it to asin/acos. This applies
+// to any out-of-range value, not just those slightly outside [-1, 1] due to
+// floating-point rounding.
+func clamp(x float64) float64 { return math.Max(-1, math.Min(1, x)) }
+
 func sinx(deg float64) float64    { return math.Sin(deg * degToRad) }
 func cosx(deg float64) float64    { return math.Cos(deg * degToRad) }
 func tanx(deg float64) float64    { return math.Tan(deg * degToRad) }
-func asinx(x float64) float64     { return radToDeg * math.Asin(x) }
-func acosx(x float64) float64     { return radToDeg * math.Acos(x) }
+func asinx(x float64) float64     { return radToDeg * math.Asin(clamp(x)) }
+func acosx(x float64) float64     { return radToDeg * math.Acos(clamp(x)) }
 func atan2x(y, x float64) float64 { return radToDeg * math.Atan2(y, x) }
 
 func sincosx(deg float64) (float64, float64) {
@@ -78,12 +84,16 @@ func sincosx(deg float64) (float64, float64) {
 }
 ```
 
-`sincosx` returns both sine and cosine in a single call — used in the lunar position loop where both are needed per term. This is a micro-optimization that reduces function call overhead over 60+ table terms.
+Key points:
 
-The angle normalization helpers keep values in canonical ranges:
+- **`clamp`** guards `asinx`/`acosx` against domain errors. Floating-point accumulation in multi-step formulas (e.g., the cosine of hour angle in `solarHourAngle`) can produce values like 1.0000000000000002 that would return NaN from `math.Asin`. The clamp catches all out-of-range values, not just rounding artifacts.
+- **`sincosx`** is a single-call optimization used in the lunar ecliptic position loop (60+ iterations per call).
+- All wrappers are unexported — callers use degrees throughout and never touch radians.
+
+### Angle normalization
 
 ```bash
-sed -n "21,35p" trig.go
+sed -n "26,40p" trig.go
 ```
 
 ```output
@@ -104,21 +114,29 @@ func mod24(x float64) float64 {
 }
 ```
 
-`mod360` normalizes angles to [0, 360). `mod24` normalizes hours to [0, 24). Both handle negative values correctly — Go's `math.Mod` preserves the sign of the dividend, so the `if x < 0` branch is necessary.
-
-**Concern: asinx/acosx domain safety.** Neither `asinx` nor `acosx` clamp inputs to [-1, 1]. Floating-point rounding could produce values like 1.0000000000000002, causing `NaN`. The library relies on mathematical proofs that valid Earth coordinates keep inputs in-bounds, but defensive clamping would be safer. [Issue #4](https://github.com/philoserf/dusk/issues/4) tracks this.
+`mod360` normalizes angles to [0, 360) and `mod24` normalizes hours to [0, 24). These appear throughout — ecliptic longitudes, right ascensions, sidereal times, and mean anomalies all need wrapping after arithmetic.
 
 ---
 
 ## Layer 2: Time and Epoch (`epoch.go`)
 
-Converts between Go's `time.Time` and the Julian Date system used in astronomical formulas. This is the bridge between wall-clock time and celestial mechanics.
+Astronomical algorithms operate on Julian dates (continuous day count since 4713 BC). `epoch.go` provides the bridge between Go `time.Time` values and Julian date arithmetic.
+
+### Julian date conversion
 
 ```bash
-sed -n "8,19p" epoch.go
+sed -n "1,44p" epoch.go
 ```
 
 ```output
+package dusk
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
 const (
 	j1970 = 2440587.5
 	j2000 = 2451545.0
@@ -126,49 +144,54 @@ const (
 
 // JulianDate returns the Julian date for a given time, i.e., the continuous
 // count of days and fractions of day since the beginning of the Julian period.
-// Uses UnixNano internally; valid for dates approximately 1677–2262.
+//
+// Uses UnixNano internally, which limits the valid range to the int64
+// nanosecond bounds (approximately 1677-09-21 to 2262-04-11). Dates outside
+// this range silently produce incorrect results because UnixNano returns 0.
+// Use [ValidJulianDateRange] to check before calling.
 func JulianDate(t time.Time) float64 {
 	ms := t.UTC().UnixNano() / 1e6
 	return float64(ms)/86400000.0 + j1970
 }
-```
 
-Two epochs anchor the calculations:
-- **J1970** (2440587.5): Julian date at Unix epoch (1970-01-01 00:00 UTC). Used to convert Unix timestamps to Julian dates.
-- **J2000** (2451545.0): Julian date at J2000.0 (2000-01-01 12:00 UTC). The reference epoch for modern astronomical calculations.
+// ErrDateOutOfRange is returned when a date falls outside the valid range
+// for [JulianDate] (the int64 nanosecond bounds, approximately
+// 1677-09-21 to 2262-04-11).
+var ErrDateOutOfRange = errors.New("dusk: date outside valid range (1677-09-21 to 2262-04-11) for JulianDate")
 
-`JulianDate` converts via milliseconds from `UnixNano()`. The integer division `/ 1e6` truncates sub-millisecond precision — acceptable for astronomical calculations where ±1ms is negligible. The `UnixNano` dependency limits the valid range to ~1677–2262 (int64 nanosecond bounds).
+// julianDateMin and julianDateMax are the bounds of the int64 UnixNano range.
+var (
+	julianDateMin = time.Unix(0, math.MinInt64).UTC()
+	julianDateMax = time.Unix(0, math.MaxInt64).UTC()
+)
 
-The reverse conversion:
-
-```bash
-sed -n "64,73p" epoch.go
-```
-
-```output
-// universalTimeFromJD converts a Julian date back to a time.Time in UTC.
-func universalTimeFromJD(jd float64) time.Time {
-	return time.Unix(0, int64((jd-j1970)*86400000.0*1e6)).UTC()
-}
-
-// datetimeZeroHour returns midnight UTC for the given date.
-func datetimeZeroHour(t time.Time) time.Time {
-	u := t.UTC()
-	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+// ValidJulianDateRange reports whether t falls within the valid range for
+// [JulianDate]. Returns nil if valid, [ErrDateOutOfRange] otherwise.
+func ValidJulianDateRange(t time.Time) error {
+	if t.Before(julianDateMin) || t.After(julianDateMax) {
+		return ErrDateOutOfRange
+	}
+	return nil
 }
 ```
 
-`universalTimeFromJD` reverses the Julian date conversion. The `(jd - j1970) * 86400000 * 1e6` converts fractional Julian days back to nanoseconds since Unix epoch.
+**Design note:** `JulianDate` uses `UnixNano()` for precision, which limits the valid range to ~1677–2262. This is a known limitation documented in the function and guarded by `ValidJulianDateRange`. Dates outside this range silently produce wrong results because Go's `UnixNano()` returns 0 for out-of-range times.
 
-### Sidereal Time
+The two epoch constants anchor the conversions:
+- `j1970` (2440587.5) — Julian date of the Unix epoch (1970-01-01 00:00 UTC)
+- `j2000` (2451545.0) — Julian date of J2000.0 (2000-01-01 12:00 TT), the standard astronomical epoch
 
-Sidereal time measures the Earth's rotation relative to the stars rather than the Sun. A sidereal day is ~23h 56m 4s. This is essential for converting between equatorial coordinates and local observation coordinates.
+### Sidereal time
 
 ```bash
-sed -n "25,45p" epoch.go
+sed -n "46,70p" epoch.go
 ```
 
 ```output
+// greenwichMeanSiderealTime returns the mean sidereal time at Greenwich in
+// degrees for the given instant.
+//
+// See Meeus, Astronomical Algorithms, eq. 12.4 p. 88.
 func greenwichMeanSiderealTime(t time.Time) float64 {
 	// Midnight UTC for the date.
 	d := datetimeZeroHour(t)
@@ -192,19 +215,65 @@ func LocalSiderealTime(t time.Time, longitude float64) float64 {
 }
 ```
 
-`greenwichMeanSiderealTime` implements Meeus eq. 12.4 (p. 88). The dominant term `360.98564736629 * (JD - j2000)` captures the Earth's rotation — slightly faster than one revolution per day (360.985... degrees vs 360). Higher-order terms account for precession and nutation.
+Sidereal time is the angle between the vernal equinox and the local meridian — it tells you what right ascension is currently on your meridian. `greenwichMeanSiderealTime` uses Meeus eq. 12.4, and `LocalSiderealTime` adjusts for the observer's longitude.
 
-`LocalSiderealTime` offsets by longitude (east = positive = earlier in sidereal time) and converts from degrees to hours (÷15).
+Note the unit convention: GMST is computed in degrees (to stay in the library's degree convention), then `LocalSiderealTime` converts to hours via `/ 15.0`. This is the only exported function in `epoch.go`.
 
-### Nutation and Obliquity
-
-The Earth's axis wobbles. Nutation is the short-period oscillation; obliquity is the tilt angle of the ecliptic.
+### Helper functions
 
 ```bash
-sed -n "79,114p" epoch.go
+sed -n "72,98p" epoch.go
 ```
 
 ```output
+// julianCentury returns the number of Julian centuries elapsed since J2000.0.
+func julianCentury(t time.Time) float64 {
+	return (JulianDate(t) - j2000) / 36525.0
+}
+
+// julianDay returns the number of days since J2000.0, rounded to the nearest
+// integer (used for mean solar time).
+func julianDay(t time.Time) int {
+	JD := JulianDate(t)
+	return int(math.Round(JD - j2000))
+}
+
+// meanSolarTime returns the mean solar time for a given instant and longitude.
+func meanSolarTime(t time.Time, longitude float64) float64 {
+	return float64(julianDay(t)) - longitude/360.0
+}
+
+// universalTimeFromJD converts a Julian date back to a time.Time in UTC.
+func universalTimeFromJD(jd float64) time.Time {
+	return time.Unix(0, int64((jd-j1970)*86400000.0*1e6)).UTC()
+}
+
+// datetimeZeroHour returns midnight UTC for the given date.
+func datetimeZeroHour(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+```
+
+These helpers form the foundation for all date-based calculations:
+
+- **`julianCentury`** — divides by 36525 (days per Julian century). Used by nutation, obliquity, and lunar calculations.
+- **`julianDay`** — rounds to integer days since J2000.0. Used by `meanSolarTime` for the NOAA solar method.
+- **`meanSolarTime`** — adjusts the day count for the observer's longitude.
+- **`universalTimeFromJD`** — reverses `JulianDate`, converting back to `time.Time`. Used to produce sunrise/sunset/twilight times.
+- **`datetimeZeroHour`** — extracts midnight UTC. Used to anchor sidereal time calculations to the start of the UT day.
+
+### Nutation and obliquity
+
+```bash
+sed -n "100,140p" epoch.go
+```
+
+```output
+// ---------------------------------------------------------------------------
+// Nutation and obliquity helpers (Meeus ch. 22, 25)
+// ---------------------------------------------------------------------------
+
 // meanObliquity returns the mean obliquity of the ecliptic in degrees.
 //
 // T is Julian centuries since J2000.0.
@@ -243,27 +312,33 @@ func lunarAscendingNode(T float64) float64 {
 }
 ```
 
-The mean obliquity (~23.44°) is the tilt of Earth's equatorial plane relative to the ecliptic. It decreases slowly (~0.013° per century). The nutation correction `nutationInObliquity` adds small periodic wobbles (±9.2 arcseconds dominant term) driven by the Moon's ascending node, with the `/ 3600.0` converting arcseconds to degrees.
+Nutation is the Earth's axial wobble (~18.6 year cycle). Obliquity is the tilt of Earth's axis (~23.4°). These affect the transformation between ecliptic and equatorial coordinates.
 
-These helpers feed into `EclipticToEquatorial`, which needs the true obliquity (mean + nutation) to convert coordinates.
+The `nutationInObliquity` function uses a simplified 4-term model (Meeus p. 144). The full Meeus model has 63 terms, but the dominant terms captured here provide sub-arcminute accuracy sufficient for rise/set calculations.
+
+Three mean-longitude functions (`solarMeanLongitude`, `lunarMeanLongitude`, `lunarAscendingNode`) are needed as arguments to the nutation formula. They appear again in the lunar position calculation.
 
 ---
 
-## Layer 3: Coordinate Systems (`coord.go`)
+## Layer 3: Coordinate Types and Conversions (`coord.go`)
 
-Astronomy uses three coordinate systems. Dusk converts between them:
+`coord.go` defines the three coordinate systems, validation logic, and the transformations between them.
 
-- **Ecliptic** (Lon, Lat, Dist): measured along the plane of Earth's orbit. Natural output of orbital mechanics.
-- **Equatorial** (RA, Dec): measured relative to the celestial equator. The standard "sky address" system.
-- **Horizontal** (Alt, Az): measured from the observer's horizon. What you actually see — "how high" and "which direction."
-
-### Types and Validation
+### Types and validation
 
 ```bash
-sed -n "9,56p" coord.go
+sed -n "1,66p" coord.go
 ```
 
 ```output
+package dusk
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
 // ErrCircumpolar is returned when a celestial object is circumpolar
 // (always above the horizon) at the given latitude.
 var ErrCircumpolar = errors.New("dusk: object is circumpolar (always above the horizon)")
@@ -276,15 +351,19 @@ var errNilLocation = errors.New("dusk: location must not be nil")
 
 // Observer represents a geographic position on Earth.
 type Observer struct {
-	Lat  float64        // latitude in degrees (north positive)
-	Lon  float64        // longitude in degrees (east positive)
-	Elev float64        // elevation in meters above sea level; negative values are treated as sea level; only affects sunrise/sunset and twilight
+	Lat float64 // latitude in degrees (north positive)
+	Lon float64 // longitude in degrees (east positive)
+	// Elev is the observer's elevation in meters above sea level.
+	// Negative values are clamped to 0 (sea level).
+	// Only affects sunrise/sunset and twilight; ignored by MoonriseMoonset
+	// and ObjectTransit.
+	Elev float64
 	Loc  *time.Location // timezone
 }
 
 var (
 	errInvalidCoord      = errors.New("dusk: latitude must be in [-90, 90] and longitude in [-180, 180]")
-	errInvalidEquatorial = errors.New("dusk: RA must be in [0, 360) and Dec in [-90, 90]")
+	errInvalidEquatorial = errors.New("dusk: Dec must be in [-90, 90]")
 )
 
 // validateObserver checks that the observer has a non-nil location and valid
@@ -305,28 +384,43 @@ type Equatorial struct {
 	Dec float64
 }
 
-// validateEquatorial checks that RA is in [0, 360) and Dec is in [-90, 90].
-func validateEquatorial(eq Equatorial) error {
-	if eq.RA < 0 || eq.RA >= 360 || eq.Dec < -90 || eq.Dec > 90 {
-		return errInvalidEquatorial
+// validateEquatorial normalizes RA to [0, 360) via mod360 and checks that
+// Dec is in [-90, 90]. Returns the normalized Equatorial or an error.
+// Non-finite RA or Dec values (NaN, ±Inf) are rejected.
+func validateEquatorial(eq Equatorial) (Equatorial, error) {
+	if math.IsNaN(eq.RA) || math.IsInf(eq.RA, 0) || math.IsNaN(eq.Dec) || math.IsInf(eq.Dec, 0) {
+		return Equatorial{}, errInvalidEquatorial
 	}
-	return nil
+	eq.RA = mod360(eq.RA)
+	if eq.Dec < -90 || eq.Dec > 90 {
+		return Equatorial{}, errInvalidEquatorial
+	}
+	return eq, nil
 }
 ```
 
-The error strategy is clean: exported sentinels (`ErrCircumpolar`, `ErrNeverRises`) for domain-specific conditions that callers may want to match with `errors.Is`, unexported sentinels (`errNilLocation`, `errInvalidCoord`) for programming errors. All prefixed with `dusk:` for clear error provenance.
+Key design decisions:
 
-`Observer` centralizes the observation point — latitude, longitude, elevation, and timezone. Every public function that produces local times accepts an `Observer`.
+- **`Observer` centralizes position** — latitude, longitude, elevation, and timezone in one struct. Every public function that produces local times takes an `Observer`.
+- **`validateEquatorial` normalizes RA** via `mod360` rather than rejecting values at 360.0. This is defensive — intermediate calculations can produce RA slightly outside [0, 360). NaN/Inf values are explicitly rejected to prevent silent propagation.
+- **`Observer.Elev`** only affects sunrise/sunset and twilight through the atmospheric refraction correction in `solarHourAngle`. Negative elevations are clamped to sea level. Moonrise and `ObjectTransit` ignore elevation entirely.
+- **Split sentinel errors** — `ErrCircumpolar` and `ErrNeverRises` are separate sentinels rather than a single "polar" error, so callers can distinguish "the sun never sets" from "the sun never rises."
 
-**Convention:** RA is in degrees [0, 360), not the traditional hours [0, 24). This avoids a unit conversion in formulas but may surprise astronomers who expect RA in hours.
-
-### Ecliptic → Equatorial Conversion
+### Ecliptic to equatorial
 
 ```bash
-sed -n "72,92p" coord.go
+sed -n "74,102p" coord.go
 ```
 
 ```output
+// Ecliptic represents ecliptic coordinates: longitude and latitude in degrees,
+// and distance in kilometers.
+type Ecliptic struct {
+	Lon  float64 // ecliptic longitude in degrees
+	Lat  float64 // ecliptic latitude in degrees
+	Dist float64 // distance in km (used for Moon)
+}
+
 // EclipticToEquatorial converts ecliptic coordinates (longitude, latitude in
 // degrees) to equatorial coordinates using nutation-corrected obliquity.
 //
@@ -350,14 +444,14 @@ func EclipticToEquatorial(t time.Time, lon, lat float64) Equatorial {
 }
 ```
 
-This is the Meeus eq. 13.3/13.4 rotation — a coordinate system rotation by the obliquity angle `eps`. The true obliquity (mean + nutation correction) accounts for the current tilt of Earth's axis. The `atan2x` for RA handles quadrant ambiguity correctly; `asinx` for Dec is safe because the formula's output is bounded by [-1, 1] for valid ecliptic coordinates.
+This is the central coordinate transformation. The ecliptic plane (Earth's orbit around the Sun) is tilted relative to the equatorial plane (Earth's equator extended into space) by the obliquity angle (~23.4°). This function rotates from one to the other, applying the nutation correction for the wobble of Earth's axis.
 
-This function is called by both `SolarPosition` and `LunarPosition` — it's the shared bridge between orbital mechanics (ecliptic) and sky observation (equatorial).
+The RA is normalized with `mod360` because `atan2x` can return negative values.
 
-### Equatorial → Horizontal Conversion
+### Equatorial to horizontal
 
 ```bash
-sed -n "94,123p" coord.go
+sed -n "104,139p" coord.go
 ```
 
 ```output
@@ -391,20 +485,22 @@ func EquatorialToHorizontal(t time.Time, obs Observer, eq Equatorial) Horizontal
 		Az:  az,
 	}
 }
+
+// HourAngle computes the hour angle in degrees from right ascension (degrees)
+// and local sidereal time (hours).
+func HourAngle(ra, lst float64) float64 {
+	return mod360(lst*15 - ra)
+}
 ```
 
-This answers "where in the sky is this object right now?" for a specific observer.
+This converts sky coordinates (RA/Dec) to what you actually see: altitude above the horizon and compass direction (azimuth). The hour angle bridges the gap — it's how far the object has rotated past your meridian.
 
-The hour angle (`ha`) is the key: it measures how far the object is from the observer's meridian. Local sidereal time minus RA gives the angular distance west of the meridian.
+The pole/zenith guard (`cosAltCosLat < 1e-10`) prevents division by zero when the observer is at a geographic pole or the object is directly overhead. In those cases azimuth is undefined, so it defaults to 0.
 
-The altitude formula (`asinx(sin(Dec)sin(Lat) + cos(Dec)cos(Lat)cos(ha))`) is standard spherical trigonometry. Note the division-by-zero guard at line 108: when the observer is at a pole or the object is at zenith, `cos(alt) * cos(lat)` approaches zero. The code defensively sets azimuth to 0° rather than producing `NaN`.
-
-The `sin(ha) > 0` test disambiguates azimuth: `acos` returns [0°, 180°], but azimuth is [0°, 360°]. When the hour angle is positive (object is west of meridian), the true azimuth is `360 - az`.
-
-### Angular Separation
+### Angular separation
 
 ```bash
-sed -n "131,144p" coord.go
+sed -n "141,155p" coord.go
 ```
 
 ```output
@@ -424,55 +520,102 @@ func AngularSeparation(ra1, dec1, ra2, dec2 float64) float64 {
 }
 ```
 
-This uses the `atan2` form of the Vincenty formula rather than the simpler `acos(dot product)`. The `acos` version loses precision when objects are very close together (near 0°) or nearly opposite (near 180°). The `atan2` version is numerically stable across the full range. Good practice.
+The `atan2` formula is more numerically stable than the simpler `acos(dot product)` approach, which loses precision near 0° and 180° separation. Parameter order is RA-first to match the `Equatorial{RA, Dec}` field order.
 
 ---
 
 ## Layer 4: Solar Calculations (`solar.go`)
 
-The Sun's position and rise/set times. This is the most-used public API.
+Solar calculations are the core use case — sunrise, sunset, and solar noon. The implementation follows the NOAA solar calculator method (derived from Meeus).
+
+### Shared solar parameters
 
 ```bash
-sed -n "75,96p" solar.go
+sed -n "17,36p" solar.go
 ```
 
 ```output
-// solarMeanAnomaly returns the Sun's mean anomaly in degrees.
-// J is the number of days since J2000.0.
-func solarMeanAnomaly(J float64) float64 {
-	return mod360(357.5291092 + 0.98560028*J)
+// solarParams holds intermediate solar position values computed from a date
+// and longitude. Used by SunriseSunset and twilight to avoid repeating the
+// 6-step parameter sequence.
+type solarParams struct {
+	delta    float64 // solar declination (degrees)
+	jTransit float64 // Julian date of solar transit (noon)
 }
 
-// solarMeanAnomalyFromCentury returns the Sun's mean anomaly in degrees.
-// T is Julian centuries since J2000.0.
-func solarMeanAnomalyFromCentury(T float64) float64 {
-	return mod360(357.5291092 + 35999.0503*T)
-}
-
-// solarEquationOfCenter returns the equation of center in degrees for a given
-// solar mean anomaly M (in degrees).
-func solarEquationOfCenter(M float64) float64 {
-	return 1.9148*sinx(M) + 0.0200*sinx(2*M) + 0.0003*sinx(3*M)
-}
-
-// solarEclipticLongitude returns the Sun's ecliptic longitude in degrees.
-func solarEclipticLongitude(M, C float64) float64 {
-	return mod360(M + C + 180 + 102.9372)
+// computeSolarParams returns the solar declination and transit JD for a given
+// date and observer longitude.
+func computeSolarParams(date time.Time, lon float64) solarParams {
+	J := meanSolarTime(date, lon)
+	M := solarMeanAnomaly(J)
+	C := solarEquationOfCenter(M)
+	lambda := solarEclipticLongitude(M, C)
+	T := julianCentury(date)
+	delta := solarDeclination(lambda, T)
+	jTransit := solarTransitJD(J, M, lambda)
+	return solarParams{delta: delta, jTransit: jTransit}
 }
 ```
 
-The solar position pipeline:
+`computeSolarParams` extracts the 6-step solar parameter sequence that was previously duplicated in `SunriseSunset`, `CivilTwilight`, `NauticalTwilight`, and `AstronomicalTwilight`. The pipeline is:
 
-1. **Mean anomaly** (`M`): where the Sun *would* be if Earth's orbit were circular. ~0.986°/day.
-2. **Equation of center** (`C`): correction for orbital eccentricity. The dominant term (1.9148°) accounts for Earth's slightly elliptical orbit.
-3. **Ecliptic longitude** (`λ`): true position along the ecliptic. The `+ 180 + 102.9372` shifts from anomaly to longitude (180° because anomaly is measured from perihelion, plus the argument of perihelion ~102.9°).
+1. `meanSolarTime` → integer day offset for longitude
+2. `solarMeanAnomaly` → M (where the Earth is in its orbit)
+3. `solarEquationOfCenter` → C (correction for elliptical orbit)
+4. `solarEclipticLongitude` → λ (Sun's position on the ecliptic)
+5. `solarDeclination` → δ (how far the Sun is above/below the equatorial plane)
+6. `solarTransitJD` → J_transit (Julian date of solar noon)
 
-Note: two mean anomaly functions exist — `solarMeanAnomaly(J)` takes *days* since J2000 (used in sunrise/sunset), while `solarMeanAnomalyFromCentury(T)` takes *centuries* (used in lunar phase where `T` is already computed). Same formula, different time units.
-
-### The Hour Angle — Where Polar Edge Cases Live
+### Sunrise and sunset
 
 ```bash
-sed -n "105,135p" solar.go
+sed -n "38,70p" solar.go
+```
+
+```output
+// SunriseSunset computes sunrise, solar noon, and sunset for the given date
+// and observer position.
+//
+// Longitude is east-positive, west-negative. An error is returned if obs.Loc is nil.
+//
+// The algorithm follows the NOAA solar calculator method (derived from Meeus,
+// Astronomical Algorithms).
+func SunriseSunset(date time.Time, obs Observer) (SunEvent, error) {
+	if err := validateObserver(obs); err != nil {
+		return SunEvent{}, err
+	}
+
+	sp := computeSolarParams(date, obs.Lon)
+
+	omega, err := solarHourAngle(sp.delta, 0, obs.Lat, obs.Elev)
+	if err != nil {
+		return SunEvent{}, err
+	}
+
+	Jrise := sp.jTransit - omega/360.0
+	Jset := sp.jTransit + omega/360.0
+
+	rise := universalTimeFromJD(Jrise).In(obs.Loc)
+	noon := universalTimeFromJD(sp.jTransit).In(obs.Loc)
+	set := universalTimeFromJD(Jset).In(obs.Loc)
+
+	return SunEvent{
+		Rise:     rise,
+		Noon:     noon,
+		Set:      set,
+		Duration: set.Sub(rise),
+	}, nil
+}
+```
+
+The sunrise/sunset calculation is symmetric around solar noon (`jTransit`). The hour angle ω (in degrees) represents how far the Sun moves from the meridian between transit and rise/set. Dividing by 360 converts the angular displacement to a fraction of a day, which is added to/subtracted from the transit JD.
+
+Depression = 0 tells `solarHourAngle` to use the standard −0.83° correction (atmospheric refraction + solar semidiameter).
+
+### Solar hour angle and polar edge cases
+
+```bash
+sed -n "119,155p" solar.go
 ```
 
 ```output
@@ -507,135 +650,58 @@ func solarHourAngle(delta, depression, lat, elev float64) (float64, error) {
 	}
 	return acosx(cosHA), nil
 }
-```
 
-This is the most subtle function in the library. It determines *when* the Sun crosses a specific altitude threshold.
-
-**The −0.83° correction** (for `depression == 0` only): accounts for atmospheric refraction (~0.566°) bending light around the horizon, plus the Sun's angular semidiameter (~0.266°). The Sun is visually "on the horizon" when its geometric center is actually 0.83° below it. For twilight, the IAU convention uses the geometric depression angle directly — no refraction/semidiameter correction.
-
-**Elevation correction**: `2.076 * sqrt(elev) / 60` — at higher elevations, you can see slightly farther past the geometric horizon. Negative elevations are clamped to 0 via `math.Max`.
-
-**Polar edge cases**: when `cosHA < -1`, the Sun never reaches the threshold (midnight sun / circumpolar). When `cosHA > 1`, it never rises above it (polar night). This is the only function that returns errors in the solar calculation chain.
-
-**Design choice**: `solarHourAngle` is shared between sunrise/sunset and twilight by parameterizing the depression angle. This avoids code duplication but requires understanding the `depression == 0` special case.
-
-### Sunrise/Sunset — The Main Public API
-
-```bash
-sed -n "17,56p" solar.go
-```
-
-```output
-// SunriseSunset computes sunrise, solar noon, and sunset for the given date
-// and observer position.
-//
-// Longitude is east-positive, west-negative. An error is returned if obs.Loc is nil.
-//
-// The algorithm follows the NOAA solar calculator method (derived from Meeus,
-// Astronomical Algorithms).
-func SunriseSunset(date time.Time, obs Observer) (SunEvent, error) {
-	if err := validateObserver(obs); err != nil {
-		return SunEvent{}, err
-	}
-
-	J := meanSolarTime(date, obs.Lon)
-	M := solarMeanAnomaly(J)
-	C := solarEquationOfCenter(M)
-	lambda := solarEclipticLongitude(M, C)
-	T := julianCentury(date)
-	delta := solarDeclination(lambda, T)
-
-	Jtransit := solarTransitJD(J, M, lambda)
-
-	omega, err := solarHourAngle(delta, 0, obs.Lat, obs.Elev)
-	if err != nil {
-		return SunEvent{}, err
-	}
-
-	Jrise := Jtransit - omega/360.0
-	Jset := Jtransit + omega/360.0
-
-	rise := universalTimeFromJD(Jrise).In(obs.Loc)
-	noon := universalTimeFromJD(Jtransit).In(obs.Loc)
-	set := universalTimeFromJD(Jset).In(obs.Loc)
-
-	return SunEvent{
-		Rise:     rise,
-		Noon:     noon,
-		Set:      set,
-		Duration: set.Sub(rise),
-	}, nil
+// solarTransitJD returns the Julian date of solar transit (solar noon).
+func solarTransitJD(J, M, lambda float64) float64 {
+	return j2000 + J + 0.0053*sinx(M) - 0.0069*sinx(2*lambda)
 }
 ```
 
-The full pipeline in action:
+This is the most subtle function in the library. The hour angle formula solves for when the Sun crosses a given altitude:
 
-1. `meanSolarTime` → integer Julian day adjusted for longitude
-2. `solarMeanAnomaly` → `solarEquationOfCenter` → `solarEclipticLongitude` → `solarDeclination`: Sun's position
-3. `solarTransitJD`: Julian date of solar noon (highest point)
-4. `solarHourAngle`: how far (in time) sunrise/sunset are from noon
-5. `Jtransit ± omega/360`: Julian dates of rise and set
-6. `universalTimeFromJD` → `.In(obs.Loc)`: back to wall-clock time
+- **depression = 0** → sunrise/sunset: uses −0.83° (0.5° refraction + 0.267° semidiameter + 0.0583° "standard" correction), adjusted for elevation
+- **depression > 0** → twilight: uses the depression angle directly (no refraction correction), per IAU/USNO convention
 
-The symmetry is elegant: sunrise is transit minus half-arc, sunset is transit plus half-arc. The `omega/360` converts the hour angle from degrees to fraction of a day.
+The elevation correction (`2.076 * √elev / 60`) accounts for the geometric dip of the horizon at altitude. Higher observers see further, so the Sun appears to rise earlier and set later.
+
+**Polar edge cases:** When `cos(HA) < -1`, the Sun never reaches the depression angle from above (it's always above) → midnight sun / circumpolar. When `cos(HA) > 1`, it never reaches it from below → polar night / never rises.
+
+### Solar position
+
+```bash
+sed -n "72,87p" solar.go
+```
+
+```output
+// SolarPosition returns the equatorial coordinates (RA, Dec) of the Sun for
+// a given instant, using the Meeus mean anomaly + equation of center method.
+//
+// Unlike SunriseSunset (which rounds J to an integer for the NOAA method),
+// this function uses continuous Julian days for precise position at any instant.
+func SolarPosition(t time.Time) Equatorial {
+	JD := JulianDate(t)
+	J := JD - j2000
+
+	M := solarMeanAnomaly(J)
+	C := solarEquationOfCenter(M)
+	lambda := solarEclipticLongitude(M, C)
+
+	// The Sun lies on the ecliptic (latitude = 0).
+	return EclipticToEquatorial(t, lambda, 0)
+}
+```
+
+`SolarPosition` differs from `computeSolarParams` in a key way: it uses continuous (fractional) Julian days instead of integer-rounded days. This gives precise Sun position at any instant, not just for a calendar date. It's used when you need the Sun's RA/Dec, not when computing rise/set times.
+
+Note that the Sun lies on the ecliptic by definition (latitude = 0), so the ecliptic-to-equatorial conversion only needs longitude.
 
 ---
 
 ## Layer 5: Lunar Calculations (`lunar.go` + `lunar_tables.go`)
 
-The Moon is far more complex than the Sun. Its orbit has large perturbations from the Sun, Jupiter, and Earth's oblateness. Meeus Chapter 47 uses over 120 periodic terms.
+The Moon's orbit is far more complex than the Sun's. Where the solar calculations use a simple 3-term equation of center, the lunar position requires summing 60+ periodic terms from Meeus Chapter 47.
 
-### Meeus Coefficient Tables
-
-```bash
-echo "=== Table 47.A: Longitude and Distance ===" && head -18 lunar_tables.go && echo "..." && echo "" && echo "=== Table 47.B: Latitude ===" && sed -n "91,101p" lunar_tables.go && echo "..." && echo "" && echo "Table 47.A entries: $(grep -c "^	{" lunar_tables.go | head -1)" && echo "Table 47.B entries: $(sed -n "/tableLat/,\$p" lunar_tables.go | grep -c "^	{")"
-```
-
-```output
-=== Table 47.A: Longitude and Distance ===
-package dusk
-
-// Meeus Table 47.A — Periodic terms for the longitude (Σl) and distance (Σr)
-// of the Moon.
-//
-// See Meeus, Astronomical Algorithms, p. 339.
-type lunarLongDistCoeff struct{ D, M, Mʹ, F, Σl, Σr float64 }
-
-// Meeus Table 47.B — Periodic terms for the latitude (Σb) of the Moon.
-//
-// See Meeus, Astronomical Algorithms, p. 341.
-type lunarLatCoeff struct{ D, M, Mʹ, F, Σb float64 }
-
-var tableLongDist = [...]lunarLongDistCoeff{
-	{0, 0, 1, 0, 6288774, -20905355},
-	{2, 0, -1, 0, 1274027, -3699111},
-	{2, 0, 0, 0, 658314, -2955968},
-	{0, 0, 2, 0, 213618, -569925},
-...
-
-=== Table 47.B: Latitude ===
-var tableLat = [...]lunarLatCoeff{
-	{0, 0, 0, 1, 5128122},
-	{0, 0, 1, 1, 280602},
-	{0, 0, 1, -1, 277693},
-	{2, 0, 0, -1, 173237},
-
-	{2, 0, -1, 1, 55413},
-	{2, 0, -1, -1, 46271},
-	{2, 0, 0, 1, 32573},
-	{0, 0, 2, 1, 17198},
-
-...
-
-Table 47.A entries: 120
-Table 47.B entries: 60
-```
-
-Each row is a periodic term: the four integers (D, M, M', F) are multipliers for the Moon's mean elongation, Sun's mean anomaly, Moon's mean anomaly, and Moon's argument of latitude. The Σl/Σr/Σb values are amplitudes in units of 0.000001° (longitude/latitude) or 0.001 km (distance).
-
-The largest longitude term (6,288,774 × 10⁻⁶ ≈ 6.29°) is the Moon's equation of center — the dominant effect of its elliptical orbit. The tables are stored as fixed-size arrays (`[...]`) rather than slices, avoiding heap allocation.
-
-### Lunar Ecliptic Position
+### Lunar ecliptic position
 
 ```bash
 sed -n "35,98p" lunar.go
@@ -708,15 +774,69 @@ func LunarEclipticPosition(t time.Time) Ecliptic {
 }
 ```
 
-The heart of lunar computation. Key implementation details:
+This is the most computationally intensive function in the library. Key details:
 
-**The E factor**: Earth's orbital eccentricity is decreasing over time. Terms involving the Sun's mean anomaly (M) must be multiplied by E (or E² for terms with |M|=2). This is a Meeus-specific correction that many simpler implementations miss.
+- **Five fundamental arguments** (D, L', M, M', F) describe the Moon's orbital parameters at time T.
+- **Three auxiliary angles** (A1, A2, A3) provide additional corrections from Meeus.
+- **E correction** accounts for the decreasing eccentricity of Earth's orbit over time. Terms involving the Sun's mean anomaly (M) are multiplied by E or E², depending on the power of M in the term.
+- **`sincosx`** computes sin and cos simultaneously for efficiency — each table row needs both for longitude/distance terms.
+- The summation loops iterate over Meeus Table 47.A (60 rows for longitude/distance) and Table 47.B (60 rows for latitude), stored in `lunar_tables.go`.
+- Final values are scaled: longitude/latitude from millionths of a degree, distance from thousandths of a km.
 
-**Table iteration**: uses `range` with pointer-to-element (`&tableLongDist[i]`) to avoid copying the struct on each iteration. The `sincosx` call computes both sin and cos of the argument in one operation — used because longitude terms need sin and distance terms need cos of the same argument.
+### Lunar tables (`lunar_tables.go`)
 
-**Output scaling**: Σl and Σb are accumulated in units of 10⁻⁶ degrees, then divided by 1e6. Σr is in units of 0.001 km, divided by 1000. The base lunar distance (385,000.56 km) is the mean Earth-Moon distance.
+```bash
+sed -n "1,13p" lunar_tables.go && echo "..." && sed -n "14,19p" lunar_tables.go && echo "    ..." && echo "}" && echo "" && sed -n "91,96p" lunar_tables.go && echo "    ..." && echo "}"
+```
 
-### Lunar Phase
+```output
+package dusk
+
+// Meeus Table 47.A — Periodic terms for the longitude (Σl) and distance (Σr)
+// of the Moon.
+//
+// See Meeus, Astronomical Algorithms, p. 339.
+type lunarLongDistCoeff struct{ D, M, Mʹ, F, Σl, Σr float64 }
+
+// Meeus Table 47.B — Periodic terms for the latitude (Σb) of the Moon.
+//
+// See Meeus, Astronomical Algorithms, p. 341.
+type lunarLatCoeff struct{ D, M, Mʹ, F, Σb float64 }
+
+...
+var tableLongDist = [...]lunarLongDistCoeff{
+	{0, 0, 1, 0, 6288774, -20905355},
+	{2, 0, -1, 0, 1274027, -3699111},
+	{2, 0, 0, 0, 658314, -2955968},
+	{0, 0, 2, 0, 213618, -569925},
+
+    ...
+}
+
+var tableLat = [...]lunarLatCoeff{
+	{0, 0, 0, 1, 5128122},
+	{0, 0, 1, 1, 280602},
+	{0, 0, 1, -1, 277693},
+	{2, 0, 0, -1, 173237},
+
+    ...
+}
+```
+
+```bash
+awk "/tableLongDist/{a=1} a && /{/{c++} a && /}$/{print \"Table 47.A (longitude/distance): \" c-1 \" entries\"; a=0; c=0}" lunar_tables.go && awk "/tableLat/{a=1} a && /{/{c++} a && /}$/{print \"Table 47.B (latitude): \" c-1 \" entries\"; a=0; c=0}" lunar_tables.go
+```
+
+```output
+Table 47.A (longitude/distance): 60 entries
+Table 47.B (latitude): 60 entries
+```
+
+The tables are stored as fixed-size arrays (`[...]`), not slices — the compiler knows the exact size and can optimize accordingly. Each entry encodes the multipliers for the fundamental arguments (D, M, M', F) and the coefficient amplitudes. These are direct transcriptions from Meeus pages 339 and 341.
+
+**Concern:** The table data is hand-transcribed from the book. Transcription errors would produce subtle position inaccuracies that might not be caught by tests unless compared against an independent implementation. The test suite validates against USNO and Stellarium values, which provides good confidence.
+
+### Lunar phase
 
 ```bash
 sed -n "100,137p" lunar.go
@@ -749,8 +869,8 @@ func LunarPhase(t time.Time) LunarPhaseInfo {
 
 	K := 100 * (1 + cosx(PA)) / 2
 
-	F := (1 - cosx(d)) / 2
-	days := F * lunarMonthDays
+	frac := (1 - cosx(d)) / 2
+	days := frac * lunarMonthDays
 
 	return LunarPhaseInfo{
 		Illumination: K,
@@ -763,16 +883,16 @@ func LunarPhase(t time.Time) LunarPhaseInfo {
 }
 ```
 
-Phase combines solar and lunar positions:
+The phase calculation combines the Sun's ecliptic longitude (simple formula) with the Moon's ecliptic position (full Chapter 47 calculation). The elongation is the angular distance between Sun and Moon as seen from Earth:
 
-1. **Elongation** (`d`): angular separation between Moon and Sun. 0° = New Moon, 180° = Full Moon. The `mod360` check distinguishes waxing (Moon east of Sun, 0-180°) from waning (180-360°).
-2. **Phase angle** (`PA`): geometric angle at the Moon between Sun and Earth. The 0.1468 correction term accounts for the Moon's and Earth's orbital eccentricities.
-3. **Illumination** (`K`): percentage of the Moon's disk that's lit, from the phase angle via `(1 + cos(PA)) / 2`.
-4. **Days approximate**: fractional position in the 29.53-day lunation cycle.
+- 0° = New Moon (Moon between Earth and Sun)
+- 90° = First Quarter
+- 180° = Full Moon (Earth between Moon and Sun)
+- 270° = Last Quarter
 
-The `Waxing` boolean is simply `d < 180` — the first half of elongation is waxing.
+The `Waxing` boolean (elongation < 180) lets callers distinguish waxing from waning phases. `DaysApprox` is symmetric — it gives days into the current half-cycle, not the overall lunation.
 
-### Moonrise/Moonset — The Brute Force Approach
+### Moonrise and moonset
 
 ```bash
 sed -n "146,204p" lunar.go
@@ -840,102 +960,50 @@ func MoonriseMoonset(date time.Time, obs Observer) (MoonEvent, error) {
 }
 ```
 
-Unlike `SunriseSunset` which uses an analytical formula, moonrise/moonset uses brute-force minute-by-minute scanning. Why?
+Unlike the Sun (where rise/set can be computed analytically), moonrise/moonset requires brute-force scanning because the Moon moves significantly (~13°/day) during the day. The scan detects altitude crossing the horizon depression threshold (−0.833° for refraction + semidiameter).
 
-The Moon moves ~13° per day (vs the Sun's ~1°), so its position changes significantly during a single day. Simple analytical formulas assume constant declination, which is a reasonable approximation for the Sun but not the Moon. The scan detects altitude sign changes across the -0.833° horizon depression threshold.
+Key details:
 
-**DST awareness**: the scan runs from local midnight to next local midnight, computing `scanMinutes` from the actual time difference. This correctly handles 23-hour (spring forward) and 25-hour (fall back) days.
+- **DST-safe scanning**: Uses local-midnight-to-local-midnight (`scanMinutes` adapts to 23h or 25h DST transition days), not a fixed 1440-minute window.
+- **Early exit**: Breaks as soon as both rise and set are found.
+- **Zero-value convention**: If the Moon doesn't rise or set during the day (possible near the poles or when the Moon is near the horizon for extended periods), the corresponding field is the zero `time.Time`.
+- **Performance**: This is the slowest function in the library. Each minute evaluates the full Chapter 47 lunar position. Benchmarks show this is the dominant cost for any caller.
 
-**Performance**: each minute requires a full `LunarEclipticPosition` → `EclipticToEquatorial` → `EquatorialToHorizontal` chain, evaluating ~120 periodic terms. This is deliberate — the doc comment warns callers about the cost. The early `break` when both rise and set are found helps.
-
-**Concern**: the ±1 minute precision is acceptable for most uses but could be improved with bisection between detected crossings. [Issue #6](https://github.com/philoserf/dusk/issues/6) proposes benchmarks to quantify the cost.
+**Concern:** The minute-by-minute resolution means moonrise/moonset times have ±1 minute precision. This can differ from USNO by several minutes for the same reason. A bisection refinement step after detecting the crossing could improve precision without significant cost, but the current accuracy is adequate for most use cases.
 
 ---
 
 ## Layer 6: Object Transit (`transit.go`)
 
-Computes rise/set/transit for arbitrary equatorial coordinates — any star, planet, or deep-sky object. Unlike the solar and lunar functions which compute positions internally, this takes pre-computed coordinates as input.
+`ObjectTransit` computes rise, set, and transit maximum for any celestial object given its equatorial coordinates. Unlike the solar and lunar functions that compute positions internally, this takes pre-computed RA/Dec as input.
 
 ```bash
-sed -n "76,94p" transit.go
+sed -n "1,85p" transit.go
 ```
 
 ```output
-// objectTransitCheck returns nil if an object at the given declination rises
-// and sets at the given latitude, ErrCircumpolar if it never sets, or
-// ErrNeverRises if it never rises.
-func objectTransitCheck(dec, lat float64) error {
-	product := tanx(lat) * tanx(dec)
-	if product >= 1 {
-		return ErrCircumpolar
-	}
-	if product <= -1 {
-		return ErrNeverRises
-	}
-	return nil
+package dusk
+
+import "time"
+
+// Transit holds rise, set, and maximum transit times for a celestial object,
+// along with the duration above the horizon.
+// When using ObjectTransit, objects that never rise or set are reported via
+// ErrCircumpolar or ErrNeverRises, and successful results always have
+// non-zero Rise, Set, and Maximum times.
+type Transit struct {
+	Rise     time.Time
+	Set      time.Time
+	Maximum  time.Time
+	Duration time.Duration
 }
 
-// argOfLSTForTransit returns the argument of LST for transit in degrees:
-// acos(-tan(lat) * tan(dec)).
-func argOfLSTForTransit(lat, dec float64) float64 {
-	return acosx(-tanx(lat) * tanx(dec))
-}
-```
-
-The circumpolar test: `tan(lat) * tan(dec) >= 1` means the object never dips below the horizon (always visible). `<= -1` means it never rises above it. This guards the subsequent `acos(-tan(lat)*tan(dec))` call, which would produce `NaN` for out-of-domain inputs.
-
-### GST ↔ UT Conversion
-
-```bash
-sed -n "102,125p" transit.go
-```
-
-```output
-// gstToUT converts Greenwich sidereal time (hours) to Universal Time (hours)
-// for the given date.
-//
-// This uses the Duffett-Smith / J1900-epoch algorithm rather than the Meeus
-// J2000-based formulas used elsewhere in the library. The two epoch systems
-// produce equivalent results; this particular algorithm is retained because it
-// maps GST→UT directly without iterative inversion.
-func gstToUT(datetime time.Time, GST float64) float64 {
-	d := datetimeZeroHour(datetime)
-	JD := JulianDate(d)
-	// January 0 is Go's representation of December 31 of the prior year.
-	JD0 := JulianDate(time.Date(datetime.Year(), 1, 0, 0, 0, 0, 0, time.UTC))
-	days := JD - JD0
-	T := (JD0 - 2415020) / 36525 // Duffett-Smith epoch (J1900)
-	R := 6.6460656 + 2400.051262*T + 0.00002581*T*T
-	B := 24 - R + float64(24*(datetime.Year()-1900))
-	T0 := (0.0657098 * days) - B
-	T0 = mod24(T0)
-	A := GST - T0
-	if A < 0 {
-		A += 24
-	}
-	return 0.997270 * A
-}
-```
-
-**Concern: mixed epoch systems.** This function uses the Duffett-Smith J1900-epoch algorithm while the rest of the library uses J2000-based Meeus formulas. The comment explains why — GST→UT inversion is non-trivial with the Meeus formulas and would require iteration. The J1900 algorithm gives a direct closed-form solution.
-
-The magic constant 2415020 is the Julian date of J1900.0 (1899-12-31 12:00 UTC). The `0.997270` factor converts sidereal time intervals to solar time intervals (a sidereal day is shorter). The `January 0` trick (`time.Date(year, 1, 0, ...)`) is Go's way of saying December 31 of the prior year — giving the Julian date at the start of the year.
-
-**Known limitation**: the J1900 epoch loses floating-point precision for dates far from 1900. For the library's valid range (~1677–2262), this is acceptable.
-
-### The Full Transit Pipeline
-
-```bash
-sed -n "17,74p" transit.go
-```
-
-```output
 // ObjectTransit computes rise, set, and transit maximum for a celestial
 // object at the given observer position on the specified date. Only the
 // calendar date (year/month/day in UTC) is used; the time-of-day is ignored.
 //
 // Observer elevation (obs.Elev) is not used; it only affects sunrise/sunset
-// and twilight calculations. Transit maximum precision is ±1 minute.
+// and twilight calculations.
 //
 // Returns an error if obs.Loc is nil or coordinates are out of range.
 // Returns ErrCircumpolar if the object never sets, or ErrNeverRises if
@@ -944,7 +1012,8 @@ func ObjectTransit(date time.Time, eq Equatorial, obs Observer) (Transit, error)
 	if err := validateObserver(obs); err != nil {
 		return Transit{}, err
 	}
-	if err := validateEquatorial(eq); err != nil {
+	var err error
+	if eq, err = validateEquatorial(eq); err != nil {
 		return Transit{}, err
 	}
 
@@ -978,8 +1047,18 @@ func ObjectTransit(date time.Time, eq Equatorial, obs Observer) (Transit, error)
 		set = nextDay.Add(time.Duration(setUTNext * float64(time.Hour))).In(obs.Loc)
 	}
 
-	// Find transit maximum by minute-by-minute scan from rise to set.
-	maximum := findTransitMaximum(rise, set, obs, eq)
+	// Transit maximum occurs when the hour angle is zero (LST = RA).
+	transitLST := eq.RA / 15 // hours
+	transitGST := lstToGST(transitLST, obs.Lon)
+	transitUT := gstToUT(date, transitGST)
+	maximum := midnight.Add(time.Duration(transitUT * float64(time.Hour))).In(obs.Loc)
+
+	// If maximum is before rise, recompute on the next day.
+	if maximum.Before(rise) {
+		nextDay := midnight.AddDate(0, 0, 1)
+		transitUTNext := gstToUT(nextDay, transitGST)
+		maximum = nextDay.Add(time.Duration(transitUTNext * float64(time.Hour))).In(obs.Loc)
+	}
 
 	return Transit{
 		Rise:     rise,
@@ -990,21 +1069,61 @@ func ObjectTransit(date time.Time, eq Equatorial, obs Observer) (Transit, error)
 }
 ```
 
-The transit pipeline converts between four time systems:
-1. **LST** (Local Sidereal Time): when the object rises/sets for *this* observer
-2. **GST** (Greenwich Sidereal Time): LST adjusted to Greenwich
-3. **UT** (Universal Time): GST converted to solar time
-4. **Local time**: UT in the observer's timezone
+The transit calculation uses the classical sidereal-time method:
 
-The `set.Before(rise)` check handles objects that set after midnight UTC — common for evening observations.
+1. **Check if the object rises/sets** — `objectTransitCheck` uses `tan(lat) × tan(dec)` to detect circumpolar/never-rises conditions.
+2. **Compute the hour angle at rise/set** — `argOfLSTForTransit` returns `acos(-tan(lat) × tan(dec))`.
+3. **Convert LST → GST → UT** — the chain goes from local sidereal time through Greenwich sidereal time to Universal Time.
+4. **Transit maximum** — computed analytically as the moment when the hour angle is zero (LST = RA/15). This is an O(1) solution that replaced an earlier O(n) minute-by-minute scan.
+5. **Day boundary handling** — if set or maximum falls before rise, it's pushed to the next day.
 
-`findTransitMaximum` uses the same minute-by-minute scan approach as moonrise/moonset, finding the moment of peak altitude. This gives ±1 minute precision.
+### GST to UT conversion
+
+```bash
+sed -n "113,141p" transit.go
+```
+
+```output
+// gstToUT converts Greenwich sidereal time (hours) to Universal Time (hours)
+// for the given date.
+//
+// This uses the Duffett-Smith / J1900-epoch algorithm rather than the Meeus
+// J2000-based formulas used elsewhere in the library. The two epoch systems
+// produce equivalent results; this particular algorithm is retained because it
+// maps GST→UT directly without iterative inversion.
+//
+// Precision note: this J1900-era sidereal-time approximation (via the
+// R/B/T0 terms) loses accuracy for dates far from 1900 due to the model
+// and floating-point arithmetic. The resulting UT remains adequate within
+// the library's valid JulianDate range (~1677–2262).
+func gstToUT(datetime time.Time, GST float64) float64 {
+	d := datetimeZeroHour(datetime)
+	JD := JulianDate(d)
+	// January 0 is Go's representation of December 31 of the prior year.
+	JD0 := JulianDate(time.Date(datetime.Year(), 1, 0, 0, 0, 0, 0, time.UTC))
+	days := JD - JD0
+	T := (JD0 - 2415020) / 36525 // Duffett-Smith epoch (J1900)
+	R := 6.6460656 + 2400.051262*T + 0.00002581*T*T
+	B := 24 - R + float64(24*(datetime.Year()-1900))
+	T0 := (0.0657098 * days) - B
+	T0 = mod24(T0)
+	A := GST - T0
+	if A < 0 {
+		A += 24
+	}
+	return 0.997270 * A
+}
+```
+
+**Concern:** `gstToUT` uses a J1900-epoch algorithm (Duffett-Smith) while the rest of the library uses J2000-based Meeus formulas. This is intentional — the J1900 algorithm provides a direct (non-iterative) GST→UT conversion. The precision note documents that accuracy degrades for dates far from 1900, but remains adequate within the `JulianDate` valid range (~1677–2262).
+
+The `0.997270` factor is the ratio of a solar day to a sidereal day (23h 56m 4.09s / 24h).
 
 ---
 
 ## Layer 7: Twilight (`twilight.go`)
 
-The simplest domain file — it reuses the entire solar pipeline with different depression angles.
+Twilight calculations reuse the solar infrastructure with different depression angles.
 
 ```bash
 cat twilight.go
@@ -1055,38 +1174,21 @@ func twilight(date time.Time, obs Observer, depression float64) (TwilightEvent, 
 	}
 
 	// Evening twilight: sunset at the given depression angle for today.
-	J := meanSolarTime(date, obs.Lon)
-	M := solarMeanAnomaly(J)
-	C := solarEquationOfCenter(M)
-	lambda := solarEclipticLongitude(M, C)
-	T := julianCentury(date)
-	delta := solarDeclination(lambda, T)
-	omega, err := solarHourAngle(delta, depression, obs.Lat, obs.Elev)
+	sp := computeSolarParams(date, obs.Lon)
+	omega, err := solarHourAngle(sp.delta, depression, obs.Lat, obs.Elev)
 	if err != nil {
 		return TwilightEvent{}, err
 	}
-	h := omega / 360
-	jTransit := solarTransitJD(J, M, lambda)
-
-	// Today's "set" at this depression = twilight dusk.
-	dusk := universalTimeFromJD(jTransit + h).In(obs.Loc)
+	dusk := universalTimeFromJD(sp.jTransit + omega/360).In(obs.Loc)
 
 	// Tomorrow's "rise" at this depression = twilight dawn.
 	tomorrow := date.AddDate(0, 0, 1)
-	J2 := meanSolarTime(tomorrow, obs.Lon)
-	M2 := solarMeanAnomaly(J2)
-	C2 := solarEquationOfCenter(M2)
-	lambda2 := solarEclipticLongitude(M2, C2)
-	T2 := julianCentury(tomorrow)
-	delta2 := solarDeclination(lambda2, T2)
-	omega2, err2 := solarHourAngle(delta2, depression, obs.Lat, obs.Elev)
+	sp2 := computeSolarParams(tomorrow, obs.Lon)
+	omega2, err2 := solarHourAngle(sp2.delta, depression, obs.Lat, obs.Elev)
 	if err2 != nil {
 		return TwilightEvent{}, err2
 	}
-	h2 := omega2 / 360
-	jTransit2 := solarTransitJD(J2, M2, lambda2)
-
-	dawn := universalTimeFromJD(jTransit2 - h2).In(obs.Loc)
+	dawn := universalTimeFromJD(sp2.jTransit - omega2/360).In(obs.Loc)
 
 	return TwilightEvent{
 		Dusk:     dusk,
@@ -1096,47 +1198,256 @@ func twilight(date time.Time, obs Observer, depression float64) (TwilightEvent, 
 }
 ```
 
-Three depression angles define the three standard twilight types:
-- **Civil** (6°): enough light for outdoor activities without artificial lighting
-- **Nautical** (12°): horizon line no longer visible at sea
-- **Astronomical** (18°): sky dark enough for faint astronomical observations
+Twilight is structurally identical to sunrise/sunset, just with a different depression angle:
 
-The `twilight` function runs the solar pipeline twice — once for today's dusk (transit + hour angle) and once for tomorrow's dawn (transit − hour angle). The `Duration` is the overnight dark period between them.
+| Type           | Depression | Meaning                                   |
+| -------------- | ---------- | ----------------------------------------- |
+| Civil          | 6°         | Enough light for outdoor activities       |
+| Nautical       | 12°        | Horizon visible at sea; bright stars only |
+| Astronomical   | 18°        | Sky fully dark for telescopes             |
 
-**Design note**: the dusk/dawn pairing is evening-centric. A call for March 8 returns tonight's dusk and tomorrow morning's dawn. To get *this morning's* dawn, you'd call with yesterday's date. This is well-documented in the `TwilightEvent` type.
+The `twilight` function computes dusk (today's evening boundary) and dawn (tomorrow morning's boundary). This "overnight" convention means callers get a complete darkness period from a single call. To get this morning's dawn, call with yesterday's date.
 
-**Concern: code duplication.** The solar pipeline (mean anomaly → equation of center → ecliptic longitude → declination → hour angle) is repeated inline here rather than being extracted into a helper. This is a minor readability issue — the repeated block is 8 lines, and extracting it would add abstraction for only two call sites.
+**Design note:** `computeSolarParams` is called twice (today and tomorrow) because the Sun's declination changes slightly between days. At high latitudes near the solstices this difference can determine whether twilight occurs at all — the polar transition test verifies this at 75°N where civil twilight succeeds on November 25 but returns `ErrNeverRises` on November 26.
 
 ---
 
-## Summary of Concerns
+## Layer 8: String Formatting (`stringer.go`)
 
-| # | Concern | Severity | Reference |
-|---|---------|----------|-----------|
-| 1 | `asinx`/`acosx` lack domain clamping for float rounding | Medium | [Issue #4](https://github.com/philoserf/dusk/issues/4) |
-| 2 | No fuzz tests for unusual input combinations | Medium | [Issue #5](https://github.com/philoserf/dusk/issues/5) |
-| 3 | No benchmarks for performance-critical paths | Medium | [Issue #6](https://github.com/philoserf/dusk/issues/6) |
-| 4 | Mixed J1900/J2000 epoch systems in `gstToUT` | Low | Documented in code |
-| 5 | Twilight duplicates solar pipeline inline | Low | 2 call sites only |
-| 6 | `MoonriseMoonset` ±1 min precision, no bisection refinement | Low | Documented in doc comment |
-| 7 | RA in degrees, not hours — potential surprise for astronomers | Low | Consistent within library |
+All eight exported result types implement `fmt.Stringer` for convenient display.
 
-## Community Standards Adherence
+```bash
+cat stringer.go
+```
 
-| Standard | Status |
-|----------|--------|
-| Go module with semantic versioning (v2) | ✓ |
-| Package doc comment (`doc.go`) | ✓ |
-| All exported symbols documented | ✓ |
-| Sentinel errors follow Go conventions | ✓ |
-| Input validation at public API boundary | ✓ |
-| Zero external dependencies | ✓ |
-| Table-driven tests | ✓ |
-| CI with vet + lint + race detector | ✓ |
-| License file (GPL-3.0) | ✓ |
-| No `init()` functions | ✓ |
-| No global mutable state | ✓ |
-| Unexported helpers keep public API clean | ✓ |
+```output
+package dusk
 
-The library follows Go community standards closely. The code is clean, well-documented, and idiomatically structured.
+import (
+	"fmt"
+	"time"
+)
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "--:--"
+	}
+	return t.Format("15:04")
+}
+
+// String returns a human-readable representation of the equatorial coordinates.
+func (e Equatorial) String() string {
+	return fmt.Sprintf("RA=%.3f° Dec=%.3f°", e.RA, e.Dec)
+}
+
+// String returns a human-readable representation of the horizontal coordinates.
+func (h Horizontal) String() string {
+	return fmt.Sprintf("Alt=%.3f° Az=%.3f°", h.Alt, h.Az)
+}
+
+// String returns a human-readable representation of the ecliptic coordinates.
+func (e Ecliptic) String() string {
+	return fmt.Sprintf("Lon=%.3f° Lat=%.3f° Dist=%.1fkm", e.Lon, e.Lat, e.Dist)
+}
+
+// String returns a human-readable representation of the sun event.
+func (s SunEvent) String() string {
+	return fmt.Sprintf("Rise=%s Noon=%s Set=%s Duration=%s",
+		formatTime(s.Rise),
+		formatTime(s.Noon),
+		formatTime(s.Set),
+		s.Duration)
+}
+
+// String returns a human-readable representation of the moon event.
+func (m MoonEvent) String() string {
+	return fmt.Sprintf("Rise=%s Set=%s Duration=%s",
+		formatTime(m.Rise),
+		formatTime(m.Set),
+		m.Duration)
+}
+
+// String returns a human-readable representation of the lunar phase.
+func (l LunarPhaseInfo) String() string {
+	namePart := l.Name
+	if namePart != "" {
+		namePart += " "
+	}
+	return fmt.Sprintf("%s%.1f%% (day %.1f)", namePart, l.Illumination, l.DaysApprox)
+}
+
+// String returns a human-readable representation of the transit event.
+func (t Transit) String() string {
+	return fmt.Sprintf("Rise=%s Max=%s Set=%s Duration=%s",
+		formatTime(t.Rise),
+		formatTime(t.Maximum),
+		formatTime(t.Set),
+		t.Duration)
+}
+
+// String returns a human-readable representation of the twilight event.
+func (tw TwilightEvent) String() string {
+	return fmt.Sprintf("Dusk=%s Dawn=%s Duration=%s",
+		formatTime(tw.Dusk),
+		formatTime(tw.Dawn),
+		tw.Duration)
+}
+```
+
+The `formatTime` helper displays `--:--` for zero-value times (events that didn't occur), keeping the output readable rather than showing Go's zero time (`0001-01-01 00:00`).
+
+Each Stringer is deliberately simple — HH:MM format for times, 3 decimal places for angles. They're designed for debugging and logging, not for user-facing display where callers would want control over formatting.
+
+---
+
+## Package Documentation (`doc.go`)
+
+```bash
+cat doc.go
+```
+
+```output
+// Package dusk provides astronomical calculations: twilight times,
+// sunrise/sunset, moonrise/moonset, lunar phase, and celestial
+// coordinate conversions.
+//
+// All angles are in degrees. Time parameters use [time.Time].
+// Functions that produce local times accept an [Observer] with a [*time.Location] field.
+// Zero-value [time.Time] signals "event did not occur" (e.g., the Moon
+// does not rise on a given day); check with [time.Time.IsZero].
+//
+// Two sentinel errors distinguish polar edge cases:
+// [ErrCircumpolar] (object always above the horizon) and
+// [ErrNeverRises] (object never rises).
+//
+// # References
+//
+//   - Meeus, Jean. Astronomical Algorithms. 2nd ed. Willmann-Bell, 1998.
+package dusk
+```
+
+The package doc follows Go conventions: a single `doc.go` file with the package-level comment. It covers the three key conventions a caller needs to know (degrees, zero-value times, sentinel errors) and cites the primary reference.
+
+---
+
+## Testing and Quality
+
+The test suite is comprehensive. Let's look at the coverage and test structure.
+
+```bash
+go test -count=1 -cover ./... 2>&1 | sed -n 's/.*\(coverage: [^ ]* of statements\).*/\1/p'
+```
+
+```output
+coverage: 100.0% of statements
+```
+
+```bash
+grep -c "func Test" *_test.go | grep -v ":0$"
+```
+
+```output
+coord_test.go:5
+epoch_test.go:6
+lunar_test.go:7
+solar_test.go:11
+stringer_test.go:13
+transit_test.go:8
+trig_test.go:9
+twilight_test.go:10
+```
+
+```bash
+grep -c "func Fuzz" fuzz_test.go
+```
+
+```output
+4
+```
+
+```bash
+grep -c "func Benchmark" benchmark_test.go
+```
+
+```output
+4
+```
+
+100% statement coverage across 69 test functions, 4 fuzz tests, and 4 benchmarks. The test suite uses:
+
+- **Table-driven tests** — expected values from USNO, Stellarium, and Meeus
+- **Edge-case coverage** — polar observers, equatorial observers, southern hemisphere, circumpolar objects, never-rises objects
+- **Fuzz tests** — `SunriseSunset`, `LunarPhase`, `ObjectTransit`, `MoonriseMoonset` with random inputs to catch panics
+- **Benchmarks** — `MoonriseMoonset`, `LunarEclipticPosition`, `SunriseSunset`, `ObjectTransit` (all 0 allocations)
+
+### Linting
+
+```bash
+cat .golangci.yml
+```
+
+```output
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - copyloopvar
+    - durationcheck
+    - errorlint
+    - gocritic
+    - misspell
+    - nilerr
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
+
+  settings:
+    gocritic:
+      disabled-checks:
+        - captLocal # Meeus convention: T (century), M (anomaly), J (day), etc.
+```
+
+```bash
+golangci-lint run 2>&1
+```
+
+```output
+0 issues.
+```
+
+The `captLocal` gocritic check is disabled because Meeus algorithms use single-letter uppercase variables by convention (T for Julian century, M for mean anomaly, J for Julian day, etc.). These are universally recognized in astronomical computing and match the textbook formulas, so flagging them as "capitalize local variable" would add noise.
+
+---
+
+## Concerns and Community Standards
+
+### Adherence to Go conventions
+
+- **Package structure**: Single package at the repo root — clean, simple, no unnecessary nesting.
+- **Naming**: Exported names follow Go conventions (`SunriseSunset`, `LunarPhase`, `Observer`). Unexported helpers use descriptive names.
+- **Error handling**: Sentinel errors with `errors.New`, checked via `errors.Is`. Functions return `(result, error)` pairs consistently.
+- **Documentation**: All exported types and functions have godoc comments. `doc.go` provides the package overview.
+- **Testing**: Table-driven tests, subtests with `t.Run`, fuzz tests, and benchmarks.
+- **Zero dependencies**: No external modules — only the Go standard library.
+
+### Potential concerns
+
+1. **`JulianDate` silent failure** — Dates outside the int64 nanosecond range (~1677–2262) silently return wrong results. `ValidJulianDateRange` exists for callers to check, but `JulianDate` itself doesn't error. This is a deliberate trade-off for API simplicity (the function is called hundreds of times internally), but callers must remember to validate at the boundary.
+
+2. **Moonrise precision** — The minute-by-minute scan gives ±1 minute accuracy. Higher precision would require either a bisection step or interpolation between the two bounding minutes. For most applications this is fine, but scientific users should be aware.
+
+3. **Mixed epoch systems** — `gstToUT` uses a J1900-era algorithm while everything else uses J2000. This works correctly within the library's valid range but could confuse maintainers. The code documents the reason (direct non-iterative conversion).
+
+4. **No `context.Context` support** — `MoonriseMoonset` takes ~0.5s per call. For server applications computing many dates, there's no way to cancel mid-computation. This is a minor concern for a library primarily used in CLI/batch contexts.
+
+5. **Meeus table transcription** — The 120 rows of lunar coefficients are transcribed from the book. While validated against independent sources, any single-digit transcription error would produce subtle inaccuracies that might only show up for specific dates.
+
+Overall, the library follows Go community standards well. The code is clean, well-tested, well-documented, and zero-dependency — it does one thing (astronomical calculations) and does it thoroughly.
 


### PR DESCRIPTION
## Summary

- Regenerate `walkthrough.md` with showboat reflecting all v2.1.0 changes
- Update `CHANGELOG.md` with complete v2.1.0 section (features, fixes, perf, refactoring, tests, infra, docs)
- Update `.claude/CLAUDE.md` architecture table with `stringer.go` and updated file descriptions
- Add `ValidJulianDateRange` and `fmt.Stringer` note to `README.md`

## Changes

- **CHANGELOG.md** — New v2.1.0 section covering all changes since v2.0.0
- **walkthrough.md** — Full regeneration: updated line counts, new sections for `stringer.go` and `computeSolarParams`, updated concerns, all blocks verified with `showboat verify`
- **.claude/CLAUDE.md** — Architecture table adds `stringer.go`, updates descriptions for `trig.go`, `epoch.go`, `coord.go`, `solar.go`, `transit.go`, `twilight.go`
- **README.md** — API section adds `ValidJulianDateRange`; Conventions section adds `fmt.Stringer` note

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run` clean
- [x] `prettier --check` passes on all markdown
- [x] `showboat verify walkthrough.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)